### PR TITLE
Added support for systemd service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'berkshelf'
 gem 'chefspec'
 gem 'foodcritic'
 gem 'rubocop'
+gem 'chef-sugar'
 
 group :integration do
   gem 'kitchen-vagrant'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'berkshelf'
 gem 'chefspec'
 gem 'foodcritic'
 gem 'rubocop'
-gem 'chef-sugar'
 
 group :integration do
   gem 'kitchen-vagrant'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/vkhatri/chef-consul-ng
 
 ## Supported OS
 
-This cookbook was tested on Amazon & Ubuntu Linux and expected to work on other RHEL platforms.
+This cookbook was tested on Amazon & Ubuntu & Centos7 Linux and expected to work on other RHEL platforms.
 
 
 ## Recipes
@@ -66,6 +66,8 @@ This cookbook was tested on Amazon & Ubuntu Linux and expected to work on other 
 * `default['consul']['diplomat_gem_version']` (default: `nil`): diplomat chef gem version
 
 * `default['consul']['install_diplomat_gem']` (default: `true`): install diplomat chef gem
+
+* `default['consul']['chef-sugar_gem_version']` (default: `nil`): chef-sugar chef gem version
 
 
 ## Core Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,8 @@ default['consul']['pid_dir'] = '/var/run/consul'
 default['consul']['diplomat_gem_version'] = nil
 default['consul']['install_diplomat_gem'] = false # enable it on specific node to manage acl
 
+default['consul']['chef-sugar_gem_version'] = nil
+
 # http://www.consul.io/docs/agent/options.html
 default['consul']['config']['bootstrap'] = false
 default['consul']['config']['server'] = false

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -40,7 +40,7 @@ template 'consul_systemd_file' do
   source "systemd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { node['init_package'] =='systemd' }
+  only_if { node['init_package'] == 'systemd' }
 end
 
 template 'consul_initd_file' do
@@ -48,7 +48,7 @@ template 'consul_initd_file' do
   source "initd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { node['init_package'] =='init' }
+  only_if { node['init_package'] == 'init' }
 end
 
 service_action = node['consul']['disable_service'] ? [:disable, :stop] : [:enable, :start]

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,10 +17,32 @@
 # limitations under the License.
 #
 
+if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
+  chef_gem 'chef-sugar' do
+    version node['consul']['chef-sugar_gem_version'] if node['consul']['chef-sugar_gem_version']
+    compile_time true
+  end
+else
+  chef_gem 'chef-sugar' do
+    version node['consul']['chef-sugar_gem_version'] if node['consul']['chef-sugar_gem_version']
+    action :nothing
+  end.run_action(:install)
+end
+
+require 'chef/sugar'
+
 file 'consul_config_file' do
   path node['consul']['conf_file']
   content JSON.pretty_generate(node['consul']['config'])
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
+end
+
+template 'consul_systemd_file' do
+  path '/etc/systemd/system/consul.service'
+  source "systemd.#{node['platform_family']}.erb"
+  mode 0744
+  notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
+  only_if { systemd? }
 end
 
 template 'consul_initd_file' do
@@ -28,6 +50,7 @@ template 'consul_initd_file' do
   source "initd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
+  only_if { upstart? }
 end
 
 service_action = node['consul']['disable_service'] ? [:disable, :stop] : [:enable, :start]

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -40,7 +40,7 @@ template 'consul_systemd_file' do
   source "systemd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { node['init_package']=='systemd'  }
+  only_if { node['init_package'] =='systemd' }
 end
 
 template 'consul_initd_file' do
@@ -48,7 +48,7 @@ template 'consul_initd_file' do
   source "initd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { node['init_package']=='init'  }
+  only_if { node['init_package'] =='init' }
 end
 
 service_action = node['consul']['disable_service'] ? [:disable, :stop] : [:enable, :start]

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,19 +17,17 @@
 # limitations under the License.
 #
 
-if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
-  chef_gem 'chef-sugar' do
-    version node['consul']['chef-sugar_gem_version'] if node['consul']['chef-sugar_gem_version']
-    compile_time true
-  end
-else
-  chef_gem 'chef-sugar' do
-    version node['consul']['chef-sugar_gem_version'] if node['consul']['chef-sugar_gem_version']
-    action :nothing
-  end.run_action(:install)
-end
-
-require 'chef/sugar'
+# if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
+#   chef_gem 'chef-sugar' do
+#     version node['consul']['chef-sugar_gem_version'] if node['consul']['chef-sugar_gem_version']
+#     compile_time true
+#   end
+# else
+#   chef_gem 'chef-sugar' do
+#     version node['consul']['chef-sugar_gem_version'] if node['consul']['chef-sugar_gem_version']
+#     action :nothing
+#   end.run_action(:install)
+# end
 
 file 'consul_config_file' do
   path node['consul']['conf_file']
@@ -42,7 +40,7 @@ template 'consul_systemd_file' do
   source "systemd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { systemd? }
+  only_if { node['init_package']=='systemd'  }
 end
 
 template 'consul_initd_file' do
@@ -50,7 +48,7 @@ template 'consul_initd_file' do
   source "initd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { upstart? }
+  only_if { node['init_package']=='init'  }
 end
 
 service_action = node['consul']['disable_service'] ? [:disable, :stop] : [:enable, :start]

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -94,6 +94,7 @@ end
 
 link '/usr/bin/consul' do
   to ::File.join(node['consul']['install_dir'], 'consul')
+  only_if { node['os']=='linux' }
 end
 
 # purge older versions

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -94,7 +94,7 @@ end
 
 link '/usr/bin/consul' do
   to ::File.join(node['consul']['install_dir'], 'consul')
-  only_if { node['os'] =='linux' }
+  only_if { node['os'] == 'linux' }
 end
 
 # purge older versions

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -94,7 +94,7 @@ end
 
 link '/usr/bin/consul' do
   to ::File.join(node['consul']['install_dir'], 'consul')
-  only_if { node['os']=='linux' }
+  only_if { node['os'] =='linux' }
 end
 
 # purge older versions

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -49,7 +49,7 @@ describe 'consul-ng::default' do
 
       it 'run ruby_block purge_old_versions' do
         expect(chef_run).to run_ruby_block('purge_old_versions')
-      end    
+      end
 
       it 'create /etc/consul/000-consul.json' do
         expect(chef_run).to create_file('/etc/consul/000-consul.json')

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -49,7 +49,7 @@ describe 'consul-ng::default' do
 
       it 'run ruby_block purge_old_versions' do
         expect(chef_run).to run_ruby_block('purge_old_versions')
-      end      
+      end    
 
       it 'create /etc/consul/000-consul.json' do
         expect(chef_run).to create_file('/etc/consul/000-consul.json')
@@ -71,7 +71,7 @@ describe 'consul-ng::default' do
   end
 
   shared_examples_for 'systemd' do
-    context 'systemd systems' do      
+    context 'systemd systems' do
       it 'create consul_systemd_file' do
         expect(chef_run).to create_template('consul_systemd_file').with(path: '/etc/systemd/system/consul.service')
       end
@@ -90,7 +90,7 @@ describe 'consul-ng::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.automatic['init_package'] ='init'
+        node.automatic['init_package'] = 'init'
         node.automatic['consul']['config']['datacenter'] = 'dc1'
         node.automatic['consul']['config']['encrypt'] = 'Dt3P9SpKGAR/DIUN1cDirg=='
         node.automatic['consul']['version_purge'] = true
@@ -106,13 +106,13 @@ describe 'consul-ng::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
         node.automatic['platform_family'] = 'debian'
-        node.automatic['init_package'] ='init'
+        node.automatic['init_package'] = 'init'
         node.automatic['consul']['config']['datacenter'] = 'dc1'
         node.automatic['consul']['config']['encrypt'] = 'Dt3P9SpKGAR/DIUN1cDirg=='
         node.automatic['consul']['version_purge'] = true
       end.converge(described_recipe)
     end
-    
+
     include_examples 'consul'
     include_examples 'initd'
     include_examples 'linux'
@@ -122,7 +122,7 @@ describe 'consul-ng::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.automatic['init_package'] ='systemd'
+        node.automatic['init_package'] = 'systemd'
         node.automatic['consul']['config']['datacenter'] = 'dc1'
         node.automatic['consul']['config']['encrypt'] = 'Dt3P9SpKGAR/DIUN1cDirg=='
         node.automatic['consul']['version_purge'] = true
@@ -133,5 +133,4 @@ describe 'consul-ng::default' do
     include_examples 'systemd'
     include_examples 'linux'
   end
-
 end

--- a/templates/default/systemd.rhel.erb
+++ b/templates/default/systemd.rhel.erb
@@ -1,0 +1,14 @@
+[Unit]
+Description=consul
+After=network.target
+
+[Service]
+Environment="GOMAXPROCS=2" "PATH=/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/bin/env consul agent -config-file=<%= node['consul']['conf_file'] %> -config-dir=<%= node['consul']['conf_dir'] %>
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=TERM
+User=<%= node['consul']['user'] %>
+WorkingDirectory=<%= node['consul']['config']['data_dir'] %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi Virender, 
I wanted to deploy this on Centos 7 which uses systemd, so I've written some code and created this pull request. I use chef/sugar gem to easily determine if systemd is used or upstart and then use the template based on that.