### PR TITLE
Allow init script to be installed for tests in kitchen-docker

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -36,7 +36,7 @@ template 'consul_initd_file' do
   source "initd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { node['init_package'] == 'init' }
+  only_if { ['init', 'sshd'].include? node['init_package'] }
 end
 
 service_action = node['consul']['disable_service'] ? [:disable, :stop] : [:enable, :start]

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -36,7 +36,7 @@ template 'consul_initd_file' do
   source "initd.#{node['platform_family']}.erb"
   mode 0744
   notifies :restart, 'service[consul]' if node['consul']['notify_restart'] && !node['consul']['disable_service']
-  only_if { ['init', 'sshd'].include? node['init_package'] }
+  only_if { %w(init sshd).include? node['init_package'] }
 end
 
 service_action = node['consul']['disable_service'] ? [:disable, :stop] : [:enable, :start]


### PR DESCRIPTION
When using [kitchen-docker](https://github.com/portertech/kitchen-docker) the `init_package` Ohai property is set to `sshd`. Use the standard sysvinit script in these scenarios.