### PR TITLE
Search is not working with double quotes around the datacenter string

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -70,7 +70,7 @@ module ConsulJoinHelper
       Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
     else
       search(
-        :node, 'consul_config_server:true AND consul_config_datacenter:\"' + datacenter + '\"',
+        :node, "consul_config_server:true AND consul_config_datacenter:#{datacenter}",
         :filter_result => { 'ip' => ['ipaddress'] }
       ).each do |result|
         unless excludeself && (result['ip'] == node['ipaddress'])


### PR DESCRIPTION
My colleague Rene previously helped out with this library and these helper functions, but somehow the search is not working with the double quotes around the datacenter, without them the search results in a correct list of LAN server IP addresses to join. Attempt 2.